### PR TITLE
Bugfix - Merging overridable properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function gulpNgConfig(moduleName, overridableProperties) {
       throw new PluginError('gulp-ng-config', 'invaild JSON file provided');
     }
 
-    jsonObj = _.assign(jsonObj, overridableProperties);
+    jsonObj = _.merge(jsonObj, overridableProperties);
 
     _.each(jsonObj, function (value, key) {
       constants.push({


### PR DESCRIPTION
Fixes https://github.com/ajwhite/gulp-ng-config/issues/1

`_.assign` (alias for `extend`) would replace entire objects, rather than just the property it was overriding. Merge does a much cleaner job of this.
