### PR TITLE
Feature - Environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,44 @@ angular.module('myApp', ['myApp.config']).run(function (string) {
 
 ## Configuration
 Currently there are a few configurable options to control the output of your configuration file:
+- [options.environment](#options.environment)
 - [options.constants](#options.constants)
 - [options.createModule](#options.createModule)
 - [options.wrap](#options.wrap)
 
+### <a id="options.environment"></a>options.environment
+Type: `String` Optional
+
+If your configuration contains multiple environments, you can supply the key you want the plugin to load from your configuration file.
+
+Example `config.json` file with multiple environments:
+```json
+{
+  "local": {
+    "EnvironmentConfig": {
+      "api": "http://localhost/"
+    }
+  },
+  "production": {
+    "EnvironmentConfig": {
+      "api": "https://api.production.com/"
+    }
+  }
+}
+```
+
+Usage of the plugin:
+```js
+gulpNgConfig('myApp.config', {
+  environment: 'production'
+})
+```
+
+Expected output:
+```js
+angular.module('myApp.config', [])
+.contant('EnvironmentConfig', {"api": "https://api.production.com/"});
+```
 
 ### <a id="options.constants"></a>options.constants
 Type: `Object` Optional

--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -12,7 +12,8 @@ function gulpNgConfig (moduleName, configuration) {
   var templateFile, stream, defaults;
   defaults = {
     createModule: true,
-    wrap: false
+    wrap: false,
+    environment: null
   };
 
   if (!moduleName) {
@@ -40,6 +41,11 @@ function gulpNgConfig (moduleName, configuration) {
     }
 
     jsonObj = _.merge({}, jsonObj, configuration.constants || {});
+
+    // select the environment in the configuration
+    if (configuration.environment && jsonObj.hasOwnProperty(configuration.environment)) {
+      jsonObj = jsonObj[configuration.environment];
+    }
 
     _.each(jsonObj, function (value, key) {
       constants.push({

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^1.9.1",
     "chai-spies": "^0.5.1",
-    "event-stream": "^3.1.7",
+    "event-stream": "^3.3.0",
     "gulp": "^3.8.7",
     "gulp-jscs": "^1.3.1",
     "gulp-jshint": "^1.8.4",

--- a/test/mocks/input_3.json
+++ b/test/mocks/input_3.json
@@ -1,0 +1,12 @@
+{
+  "environmentA": {
+    "one": {
+      "two": "three"
+    }
+  },
+  "environmentB": {
+    "four": {
+      "five": "six"
+    }
+  }
+}

--- a/test/mocks/output_10.js
+++ b/test/mocks/output_10.js
@@ -1,0 +1,3 @@
+angular.module('gulp-ng-config', [])
+.constant('environmentA', {"one":{"two":"three"}})
+.constant('environmentB', {"four":{"five":"six"}});

--- a/test/mocks/output_8.js
+++ b/test/mocks/output_8.js
@@ -1,0 +1,2 @@
+angular.module('gulp-ng-config', [])
+.constant('one', {"two":"three"});

--- a/test/mocks/output_9.js
+++ b/test/mocks/output_9.js
@@ -1,0 +1,2 @@
+angular.module('gulp-ng-config', [])
+.constant('four', {"five":"six"});

--- a/test/stream.js
+++ b/test/stream.js
@@ -166,5 +166,42 @@ describe('gulp-ng-config', function () {
         done();
       }));
     });
+    it ('should select an embedded json object if an environment key is supplied and the key exists', function (done) {
+      var expectedOutputA = fs.readFileSync(path.normalize(__dirname + '/mocks/output_8.js')), // match envA
+          expectedOutputB = fs.readFileSync(path.normalize(__dirname + '/mocks/output_9.js')), // match envB
+          expectedOutputC = fs.readFileSync(path.normalize(__dirname + '/mocks/output_10.js')), // no match
+          streamA = gulp.src(path.normalize(__dirname + '/mocks/input_3.json')),
+          streamB = gulp.src(path.normalize(__dirname + '/mocks/input_3.json')),
+          streamC = gulp.src(path.normalize(__dirname + '/mocks/input_3.json'));
+
+      // tests output with `environmentA`
+      streamA.pipe(plugin('gulp-ng-config', {
+        environment: 'environmentA'
+      }))
+      .pipe(through.obj(function (file) {
+        expect(file.contents.toString()).to.equal(expectedOutputA.toString());
+      }));
+
+      // tests output with `environmentB`
+      streamB.pipe(plugin('gulp-ng-config', {
+        environment: 'environmentB'
+      }))
+      .pipe(through.obj(function (file) {
+        expect(file.contents.toString()).to.equal(expectedOutputB.toString());
+      }));
+
+      // tests output with no matching environment key
+      streamC.pipe(plugin('gulp-ng-config', {
+        environment: 'nonExistant'
+      }))
+      .pipe(through.obj(function (file) {
+        expect(file.contents.toString()).to.equal(expectedOutputC.toString());
+      }));
+
+      es.merge(streamA, streamB, streamC)
+      .pipe(through.obj(function () {
+        done();
+      }));
+    });
   });
 });


### PR DESCRIPTION
Adds support for multiple config environments in one file by supplying a key for the plugin to use to filter out the object properties

https://github.com/ajwhite/gulp-ng-config/issues/13