### PR TITLE
use double quotes for strings in output file

### DIFF
--- a/template.html
+++ b/template.html
@@ -1,2 +1,2 @@
-angular.module('<%= moduleName %>'<% if (createModule) { %>, []<% } %>)<% _.forEach(constants, function (constant) { %>
-.constant('<%= constant.name %>', <%= constant.value %>)<% }); %>;
+angular.module("<%= moduleName %>"<% if (createModule) { %>, []<% } %>)<% _.forEach(constants, function (constant) { %>
+.constant("<%= constant.name %>", <%= constant.value %>)<% }); %>;

--- a/test/mocks/output_1.js
+++ b/test/mocks/output_1.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config', [])
-.constant('one', "two");
+angular.module("gulp-ng-config", [])
+.constant("one", "two");

--- a/test/mocks/output_10.js
+++ b/test/mocks/output_10.js
@@ -1,3 +1,3 @@
-angular.module('gulp-ng-config', [])
-.constant('environmentA', {"one":{"two":"three"}})
-.constant('environmentB', {"four":{"five":"six"}});
+angular.module("gulp-ng-config", [])
+.constant("environmentA", {"one":{"two":"three"}})
+.constant("environmentB", {"four":{"five":"six"}});

--- a/test/mocks/output_11.js
+++ b/test/mocks/output_11.js
@@ -1,3 +1,3 @@
-angular.module('gulp-ng-config', [])
-.constant('one', {"two":"three"})
-.constant('constant', "value");
+angular.module("gulp-ng-config", [])
+.constant("one", {"two":"three"})
+.constant("constant", "value");

--- a/test/mocks/output_2.js
+++ b/test/mocks/output_2.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config', [])
-.constant('one', {"two":"three"});
+angular.module("gulp-ng-config", [])
+.constant("one", {"two":"three"});

--- a/test/mocks/output_3.js
+++ b/test/mocks/output_3.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config', [])
-.constant('one', {"two":"four"});
+angular.module("gulp-ng-config", [])
+.constant("one", {"two":"four"});

--- a/test/mocks/output_4.js
+++ b/test/mocks/output_4.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config', [])
-.constant('one', {"two":"three","three":"four"});
+angular.module("gulp-ng-config", [])
+.constant("one", {"two":"three","three":"four"});

--- a/test/mocks/output_5.js
+++ b/test/mocks/output_5.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config')
-.constant('one', {"two":"three"});
+angular.module("gulp-ng-config")
+.constant("one", {"two":"three"});

--- a/test/mocks/output_6.js
+++ b/test/mocks/output_6.js
@@ -1,5 +1,5 @@
 (function () { 
- return angular.module('gulp-ng-config', [])
-.constant('one', {"two":"three"});
+ return angular.module("gulp-ng-config", [])
+.constant("one", {"two":"three"});
 
 })();

--- a/test/mocks/output_7.js
+++ b/test/mocks/output_7.js
@@ -1,4 +1,4 @@
 define(['angular', function () {
- return angular.module('gulp-ng-config', [])
-.constant('one', {"two":"three"});
+ return angular.module("gulp-ng-config", [])
+.constant("one", {"two":"three"});
 }]);

--- a/test/mocks/output_8.js
+++ b/test/mocks/output_8.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config', [])
-.constant('one', {"two":"three"});
+angular.module("gulp-ng-config", [])
+.constant("one", {"two":"three"});

--- a/test/mocks/output_9.js
+++ b/test/mocks/output_9.js
@@ -1,2 +1,2 @@
-angular.module('gulp-ng-config', [])
-.constant('four', {"five":"six"});
+angular.module("gulp-ng-config", [])
+.constant("four", {"five":"six"});


### PR DESCRIPTION
This is a fix for #12

Changes:
- `template.html` uses double quotes for module name and constant names
- Changed `test/mock/output_*.js` to expect double quotes

Now this module's output is all double quoted instead of a mix of single and double.