### PR TITLE
Touch up yaml code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ object:
 
 ```javascript
 gulp.src("config.yml")
-gulpNgConfig('myApp.config', {
+.pipe(gulpNgConfig('myApp.config', {
   parser: 'yml'
-});
+}));
 ```
 
 Generating,


### PR DESCRIPTION
yaml code example in readme was missing a `pipe()` call