### PR TITLE
Emit error on invalid environment option

### DIFF
--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -62,8 +62,12 @@ function gulpNgConfig (moduleName, configuration) {
     }
 
     // select the environment in the configuration
-    if (configuration.environment && jsonObj.hasOwnProperty(configuration.environment)) {
-      jsonObj = jsonObj[configuration.environment];
+    if (configuration.environment) {
+      if (jsonObj.hasOwnProperty(configuration.environment)) {
+        jsonObj = jsonObj[configuration.environment];
+      } else {
+        return this.emit('error', new PluginError(PLUGIN_NAME, 'invalid \'environment\' value'));
+      }
     }
 
     jsonObj = _.merge({}, jsonObj, configuration.constants || {});

--- a/test/stream.js
+++ b/test/stream.js
@@ -242,6 +242,24 @@ describe('gulp-ng-config', function () {
           }));
     });
 
+    it('should emit an error if an environment key is supplied and the key does not exist', function (done) {
+      var stream = gulp.src(path.normalize(__dirname + '/mocks/input_3.json')),
+          spy = chai.spy();
+      expect(function () {
+        stream.pipe(plugin('gulp-ng-config', {
+          environment: 'env'
+        })).on('error', function () {
+          spy();
+          this.emit('end');
+        }).on('end', function () {
+          expect(spy).to.have.been.called();
+          done();
+        }).pipe(through.obj(function () {
+          done();
+        }));
+      }).to.not.throw();
+    });
+
     it('should merge environment keys with constant keys', function (done) {
       var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_11.js')),
           streamA = gulp.src(path.normalize(__dirname + '/mocks/input_3.json'));

--- a/test/stream.js
+++ b/test/stream.js
@@ -217,10 +217,8 @@ describe('gulp-ng-config', function () {
     it('should select an embedded json object if an environment key is supplied and the key exists', function (done) {
       var expectedOutputA = fs.readFileSync(path.normalize(__dirname + '/mocks/output_8.js')), // match envA
           expectedOutputB = fs.readFileSync(path.normalize(__dirname + '/mocks/output_9.js')), // match envB
-          expectedOutputC = fs.readFileSync(path.normalize(__dirname + '/mocks/output_10.js')), // no match
           streamA = gulp.src(path.normalize(__dirname + '/mocks/input_3.json')),
-          streamB = gulp.src(path.normalize(__dirname + '/mocks/input_3.json')),
-          streamC = gulp.src(path.normalize(__dirname + '/mocks/input_3.json'));
+          streamB = gulp.src(path.normalize(__dirname + '/mocks/input_3.json'));
 
       // tests output with `environmentA`
       streamA.pipe(plugin('gulp-ng-config', {
@@ -238,15 +236,7 @@ describe('gulp-ng-config', function () {
             expect(file.contents.toString()).to.equal(expectedOutputB.toString());
           }));
 
-      // tests output with no matching environment key
-      streamC.pipe(plugin('gulp-ng-config', {
-        environment: 'nonExistant'
-      }))
-          .pipe(through.obj(function (file) {
-            expect(file.contents.toString()).to.equal(expectedOutputC.toString());
-          }));
-
-      es.merge(streamA, streamB, streamC)
+      es.merge(streamA, streamB)
           .pipe(through.obj(function () {
             done();
           }));


### PR DESCRIPTION
Fixes #39 

I tried to write a unittest for this one, but I'm relativly new to node and staff, so there is some problem. Here is a code:
`expect(spy).to.have.been.called();` reports that it was not called, but if I replace  `.on('error', spy);` with `gutil.log`, then I can see that `gutil.log` does get called.

```js
    it('should emit an error if an environment key is supplied and the key does not exists', function () {
      var stream = gulp.src(path.normalize(__dirname + '/mocks/input_3.json')),
          spy = chai.spy();
      expect(function () {
        stream.pipe(plugin('gulp-ng-config', {
          environment: 'env'
        })).on('error', spy);
      }).to.not.throw(Error);
      expect(spy).to.have.been.called();
    });

```