### PR TITLE
Allow configuration of moduleType as constant or value

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Currently there are a few configurable options to control the output of your con
 - [options.environment](#options.environment)
 - [options.constants](#options.constants)
 - [options.createModule](#options.createModule)
+- [options.type](#options.type)
 - [options.wrap](#options.wrap)
 - [options.parser](#options.parser)
 
@@ -154,6 +155,26 @@ angular.module('myApp.config', [])
 .constant('array', ["one",2,{"three":"four"},[5,"six"]])
 .constant('random', "value");
 
+```
+
+### <a id="options.type"></a>options.type
+Type: `String` Default value: `'constant'` Optional
+
+This allows configuring the type of service that is created -- a `constant` or a `value`. By default, a `constant` is created, but a `value` can be overridden. Possible types:
+
+- `'constant'`
+- `'value'`
+
+```javascript
+gulpNgConfig('myApp.config', {
+  type: 'value'
+});
+```
+
+This will produce `configFile.js` with a `value` service.
+```javascript
+angular.module('myApp.config', [])
+.value('..', '..');
 ```
 
 ### <a id="options.createModule"></a>options.createModule

--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -7,14 +7,14 @@ var through = require('through2'),
     jsYaml = require('js-yaml'),
     templateFilePath = __dirname + '/template.html',
     PluginError = gutil.PluginError,
-    VALID_MODULE_TYPES = ['constant', 'value'],
+    VALID_TYPES = ['constant', 'value'],
     PLUGIN_NAME = 'gulp-ng-config',
     WRAP_TEMPLATE = '(function () { \n return <%= module %>\n})();\n';
 
 function gulpNgConfig (moduleName, configuration) {
   var templateFile, stream, defaults;
   defaults = {
-    moduleType: 'constant',
+    type: 'constant',
     createModule: true,
     wrap: false,
     environment: null,
@@ -78,8 +78,8 @@ function gulpNgConfig (moduleName, configuration) {
       }
     }
 
-    if (!_.contains(VALID_MODULE_TYPES, configuration.moduleType)) {
-      this.emit('error', new PluginError(PLUGIN_NAME, 'invalid \'moduleType\' value'));
+    if (!_.contains(VALID_TYPES, configuration.type)) {
+      this.emit('error', new PluginError(PLUGIN_NAME, 'invalid \'type\' value'));
       return callback();
     }
 
@@ -109,7 +109,7 @@ function gulpNgConfig (moduleName, configuration) {
     templateOutput = _.template(templateFile)({
       createModule: configuration.createModule,
       moduleName: moduleName,
-      moduleType: configuration.moduleType,
+      type: configuration.type,
       constants: constants
     });
 

--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -7,12 +7,14 @@ var through = require('through2'),
     jsYaml = require('js-yaml'),
     templateFilePath = __dirname + '/template.html',
     PluginError = gutil.PluginError,
+    VALID_MODULE_TYPES = ['constant', 'value'],
     PLUGIN_NAME = 'gulp-ng-config',
     WRAP_TEMPLATE = '(function () { \n return <%= module %>\n})();\n';
 
 function gulpNgConfig (moduleName, configuration) {
   var templateFile, stream, defaults;
   defaults = {
+    moduleType: 'constant',
     createModule: true,
     wrap: false,
     environment: null,
@@ -76,6 +78,11 @@ function gulpNgConfig (moduleName, configuration) {
       }
     }
 
+    if (!_.contains(VALID_MODULE_TYPES, configuration.moduleType)) {
+      this.emit('error', new PluginError(PLUGIN_NAME, 'invalid \'moduleType\' value'));
+      return callback();
+    }
+
     jsonObj = _.merge({}, jsonObj, configuration.constants || {});
 
     var spaces = 0;
@@ -102,6 +109,7 @@ function gulpNgConfig (moduleName, configuration) {
     templateOutput = _.template(templateFile)({
       createModule: configuration.createModule,
       moduleName: moduleName,
+      moduleType: configuration.moduleType,
       constants: constants
     });
 

--- a/template.html
+++ b/template.html
@@ -1,2 +1,2 @@
 angular.module("<%= moduleName %>"<% if (createModule) { %>, []<% } %>)<% _.forEach(constants, function (constant) { %>
-.constant("<%= constant.name %>", <%= constant.value %>)<% }); %>;
+.<%= moduleType %>("<%= constant.name %>", <%= constant.value %>)<% }); %>;

--- a/template.html
+++ b/template.html
@@ -1,2 +1,2 @@
 angular.module("<%= moduleName %>"<% if (createModule) { %>, []<% } %>)<% _.forEach(constants, function (constant) { %>
-.<%= moduleType %>("<%= constant.name %>", <%= constant.value %>)<% }); %>;
+.<%= type %>("<%= constant.name %>", <%= constant.value %>)<% }); %>;

--- a/test/mocks/output_16.js
+++ b/test/mocks/output_16.js
@@ -1,0 +1,2 @@
+angular.module("gulp-ng-config", [])
+.value("one", {"two":"three"});

--- a/test/stream.js
+++ b/test/stream.js
@@ -315,6 +315,51 @@ describe('gulp-ng-config', function () {
             done();
           }));
     });
+    describe ('moduleType', function () {
+      it('should generate a `value` module if `moduleType` is specified with `value`', function (done) {
+        var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_16.js'));
+        gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
+          .pipe(plugin('gulp-ng-config', {
+            moduleType: 'value'
+          }))
+          .pipe(through.obj(function (file) {
+            expect(file.contents.toString()).to.equal(expectedOutput.toString());
+            done();
+          }));
+      });
+      it ('should generate a `constant` module if `moduleType` is specified with a `constant`', function (done) {
+        var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_15.js'));
+        gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
+          .pipe(plugin('gulp-ng-config', {
+            moduleType: 'constant'
+          }))
+          .pipe(through.obj(function (file) {
+            expect(file.contents.toString()).to.equal(expectedOutput.toString());
+            done();
+          }));
+      });
+      it ('should generate a `constant` module by default if `moduleTye` is not supplied', function (done) {
+        var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_15.js'));
+        gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
+          .pipe(plugin('gulp-ng-config', {
+            moduleType: undefined
+          }))
+          .pipe(through.obj(function (file) {
+            expect(file.contents.toString()).to.equal(expectedOutput.toString());
+            done();
+          }));
+      });
+      it ('should emit an error if an invalid `moduleType` is supplied', function (done) {
+        gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
+          .pipe(plugin('gulp-ng-config', {
+            moduleType: 'invalid'
+          }))
+          .on('error', function (error) {
+            expect(error.message).to.be.eql('invalid \'moduleType\' value');
+            done();
+          });
+      });
+    });
     //it ('should generate an error when unacceptable value passed as pretty param', function (done) {
     //TODO should handle an error
     //var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_13.js'));

--- a/test/stream.js
+++ b/test/stream.js
@@ -315,23 +315,23 @@ describe('gulp-ng-config', function () {
             done();
           }));
     });
-    describe ('moduleType', function () {
-      it('should generate a `value` module if `moduleType` is specified with `value`', function (done) {
+    describe ('type', function () {
+      it('should generate a `value` module if `type` is specified with `value`', function (done) {
         var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_16.js'));
         gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
           .pipe(plugin('gulp-ng-config', {
-            moduleType: 'value'
+            type: 'value'
           }))
           .pipe(through.obj(function (file) {
             expect(file.contents.toString()).to.equal(expectedOutput.toString());
             done();
           }));
       });
-      it ('should generate a `constant` module if `moduleType` is specified with a `constant`', function (done) {
+      it ('should generate a `constant` module if `type` is specified with a `constant`', function (done) {
         var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_15.js'));
         gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
           .pipe(plugin('gulp-ng-config', {
-            moduleType: 'constant'
+            type: 'constant'
           }))
           .pipe(through.obj(function (file) {
             expect(file.contents.toString()).to.equal(expectedOutput.toString());
@@ -342,20 +342,20 @@ describe('gulp-ng-config', function () {
         var expectedOutput = fs.readFileSync(path.normalize(__dirname + '/mocks/output_15.js'));
         gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
           .pipe(plugin('gulp-ng-config', {
-            moduleType: undefined
+            type: undefined
           }))
           .pipe(through.obj(function (file) {
             expect(file.contents.toString()).to.equal(expectedOutput.toString());
             done();
           }));
       });
-      it ('should emit an error if an invalid `moduleType` is supplied', function (done) {
+      it ('should emit an error if an invalid `type` is supplied', function (done) {
         gulp.src(path.normalize(__dirname + '/mocks/input_2.json'))
           .pipe(plugin('gulp-ng-config', {
-            moduleType: 'invalid'
+            type: 'invalid'
           }))
           .on('error', function (error) {
-            expect(error.message).to.be.eql('invalid \'moduleType\' value');
+            expect(error.message).to.be.eql('invalid \'type\' value');
             done();
           });
       });


### PR DESCRIPTION
This introduces the functionality from #37 to allow generating a `value` or `constant`.