### PR TITLE
New configuration properties

### DIFF
--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -20,7 +20,11 @@ function gulpNgConfig (moduleName, configuration) {
     wrap: false,
     environment: null,
     parser: null,
-    pretty: false
+    pretty: false,
+    /* New supported plugin configuration properties */
+    embedInObject: false,
+    stripPrivateProperties: false,
+    stripHeadingCharacter: '_'
   };
 
   if (!moduleName) {
@@ -100,7 +104,23 @@ function gulpNgConfig (moduleName, configuration) {
       ));
       return callback();
     }
+    
+    // Add only non private properties
+    if(configuration.stripPrivateProperties) {
+      _.each(jsonObj, function (value, key) {
+        if(key[0] === configuration.stripHeadingCharacter) {
+          delete jsonObj[key];
+        } // if
+      });
+    };
 
+    // Embed configuration in a new object
+    if(configuration.embedInObject && typeof configuration.embedInObject === 'string') {
+      var embeddedProperties = {};
+      embeddedProperties[configuration.embedInObject] = jsonObj;
+      jsonObj = embeddedProperties;
+    } // if
+    
     _.each(jsonObj, function (value, key) {
       constants.push({
         name: key,
@@ -128,7 +148,7 @@ function gulpNgConfig (moduleName, configuration) {
         module: templateOutput
       });
     }
-
+    
     file.path = gutil.replaceExtension(file.path, '.js');
     file.contents = new Buffer(templateOutput);
     this.push(file);

--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -23,8 +23,7 @@ function gulpNgConfig (moduleName, configuration) {
     pretty: false,
     /* New supported plugin configuration properties */
     embedInObject: false,
-    stripPrivateProperties: false,
-    stripHeadingCharacter: '_'
+    blacklist: false
   };
 
   if (!moduleName) {
@@ -106,9 +105,9 @@ function gulpNgConfig (moduleName, configuration) {
     }
     
     // Add only non private properties
-    if(configuration.stripPrivateProperties) {
+    if(configuration.blacklist instanceof RegExp) {
       _.each(jsonObj, function (value, key) {
-        if(key[0] === configuration.stripHeadingCharacter) {
+        if(configuration.blacklist.test(key)) {
           delete jsonObj[key];
         } // if
       });


### PR DESCRIPTION
I was thinking about adding a couple of useful properties to this awesome package.

I usually share configuration between backend and frontend, for example API endpoints, client tokens and so on. What I would find useful is a feature that let me specify some "private properties" that are not brought to the frontend angular configuration file. I ususally specify those properties with a heading underscore, so I added these two properties to _gulp-ng-config_:
- **stripPrivateProperties**: if true, it will search for configuration properties to delete before building the Angular configuration file
- **stripHeadingCharacter**: is the character to search, by default it's '_'

Secondly, I usually attach all properties to a single object, for example:

``` javascript
angular.module("app.config", [])
.constant("Config", {
  "auth": {
    "clientToken": {
      "name": "x-client-token",
      "value": "abcde"
    }
  },
  "restApiRoot": "/api/v1"
});
```

This way, you can avoid some namespace pollution issues in your controllers.

If you think they could be useful, I would like to add some tests and maybe push everything to the main repo.

Regards,

Roberto
