### PR TITLE
Fix issue with linters that prefer single quotes

### DIFF
--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -9,7 +9,7 @@ var through = require('through2'),
     PluginError = gutil.PluginError,
     VALID_TYPES = ['constant', 'value'],
     PLUGIN_NAME = 'gulp-ng-config',
-    WRAP_TEMPLATE = '(function () { \n return <%= module %>\n})();\n',
+    WRAP_TEMPLATE = '(function () {\n return <%= module %>\n})();\n',
     ES6_TEMPLATE = 'import angular from \'angular\';\nexport default <%= module %>';
 
 function gulpNgConfig (moduleName, configuration) {
@@ -104,7 +104,7 @@ function gulpNgConfig (moduleName, configuration) {
     _.each(jsonObj, function (value, key) {
       constants.push({
         name: key,
-        value: JSON.stringify(value, null, spaces)
+        value: JSON.stringify(value, null, spaces).replace(/"/g, '\'')
       });
     });
 

--- a/template.html
+++ b/template.html
@@ -1,2 +1,2 @@
-angular.module("<%= moduleName %>"<% if (createModule) { %>, []<% } %>)<% _.forEach(constants, function (constant) { %>
-.<%= type %>("<%= constant.name %>", <%= constant.value %>)<% }); %>;
+angular.module('<%= moduleName %>'<% if (createModule) { %>, []<% } %>)<% _.forEach(constants, function (constant) { %>
+.<%= type %>('<%= constant.name %>', <%= constant.value %>)<% }); %>;

--- a/test/mocks/output_1.js
+++ b/test/mocks/output_1.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", "two");
+angular.module('gulp-ng-config', [])
+.constant('one', 'two');

--- a/test/mocks/output_10.js
+++ b/test/mocks/output_10.js
@@ -1,3 +1,3 @@
-angular.module("gulp-ng-config", [])
-.constant("environmentA", {"one":{"two":"three"}})
-.constant("environmentB", {"four":{"five":"six"}});
+angular.module('gulp-ng-config', [])
+.constant('environmentA', {'one':{'two':'three'}})
+.constant('environmentB', {'four':{'five':'six'}});

--- a/test/mocks/output_11.js
+++ b/test/mocks/output_11.js
@@ -1,3 +1,3 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"})
-.constant("constant", "value");
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'})
+.constant('constant', 'value');

--- a/test/mocks/output_12.js
+++ b/test/mocks/output_12.js
@@ -1,4 +1,4 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {
-  "two": "three"
+angular.module('gulp-ng-config', [])
+.constant('one', {
+  'two': 'three'
 });

--- a/test/mocks/output_13.js
+++ b/test/mocks/output_13.js
@@ -1,4 +1,4 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {
-    "two": "three"
+angular.module('gulp-ng-config', [])
+.constant('one', {
+    'two': 'three'
 });

--- a/test/mocks/output_14.js
+++ b/test/mocks/output_14.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});

--- a/test/mocks/output_15.js
+++ b/test/mocks/output_15.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});

--- a/test/mocks/output_16.js
+++ b/test/mocks/output_16.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.value("one", {"two":"three"});
+angular.module('gulp-ng-config', [])
+.value('one', {'two':'three'});

--- a/test/mocks/output_17.js
+++ b/test/mocks/output_17.js
@@ -1,3 +1,3 @@
 import angular from 'angular';
-export default angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+export default angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});

--- a/test/mocks/output_2.js
+++ b/test/mocks/output_2.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});

--- a/test/mocks/output_3.js
+++ b/test/mocks/output_3.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"four"});
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'four'});

--- a/test/mocks/output_4.js
+++ b/test/mocks/output_4.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three","three":"four"});
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three','three':'four'});

--- a/test/mocks/output_5.js
+++ b/test/mocks/output_5.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config")
-.constant("one", {"two":"three"});
+angular.module('gulp-ng-config')
+.constant('one', {'two':'three'});

--- a/test/mocks/output_6.js
+++ b/test/mocks/output_6.js
@@ -1,5 +1,5 @@
-(function () { 
- return angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+(function () {
+ return angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});
 
 })();

--- a/test/mocks/output_7.js
+++ b/test/mocks/output_7.js
@@ -1,4 +1,4 @@
 define(['angular', function () {
- return angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+ return angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});
 }]);

--- a/test/mocks/output_8.js
+++ b/test/mocks/output_8.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("one", {"two":"three"});
+angular.module('gulp-ng-config', [])
+.constant('one', {'two':'three'});

--- a/test/mocks/output_9.js
+++ b/test/mocks/output_9.js
@@ -1,2 +1,2 @@
-angular.module("gulp-ng-config", [])
-.constant("four", {"five":"six"});
+angular.module('gulp-ng-config', [])
+.constant('four', {'five':'six'});


### PR DESCRIPTION
Activity: ajwhite/gulp-ng-config/issues/12

I ran into [this issue](ajwhite/gulp-ng-config/issues/12) as well where linters (Sonarlint in my case) take
exception to the double-quotes output. I've changed the template and
test files to use single-quotes and am using .replace on the
template.constant.value to replace double-quotes with single-quotes.

Tests pass.