### PR TITLE
fix issue #58: lodash v4.x.x compatibility

### DIFF
--- a/gulp-ng-config.js
+++ b/gulp-ng-config.js
@@ -99,7 +99,7 @@ function gulpNgConfig (moduleName, configuration) {
       }, this), {});
     }
 
-    if (!_.contains(VALID_TYPES, configuration.type)) {
+    if (!_.includes(VALID_TYPES, configuration.type)) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'invalid \'type\' value'));
       return callback();
     }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/ajwhite/gulp-ng-config",
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.3",
     "through2": "^2.0.0",
     "js-yaml": "3.4.3"
   },


### PR DESCRIPTION
Fixing #58 

I reviewed lodash changelogs, finding that just avoiding the use of _.contains (deleted alias) it's enough to make the project compatible with v4.